### PR TITLE
Add masked loads in SDD to support K that is not a multiple of BLOCK_K

### DIFF
--- a/stk/backend/triton_kernels.py
+++ b/stk/backend/triton_kernels.py
@@ -34,8 +34,8 @@ def _sdd_kernel(A, B, C, M, N, K,
     # do matrix multiplication
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
     for k in range(0, tl.cdiv(K, BLOCK_K)):
-        a = tl.load(A)
-        b = tl.load(B)
+        a = tl.load(A, mask=rk[None, :] < K - k * BLOCK_K, other=0.0)
+        b = tl.load(B, mask=rk[:, None] < K - k * BLOCK_K, other=0.0)
         acc += tl.dot(a, b)
         A += BLOCK_K * stride_ak
         B += BLOCK_K * stride_bk


### PR DESCRIPTION
Adding load masking (inspired by the [triton guide](https://triton-lang.org/main/getting-started/tutorials/03-matrix-multiplication.html)) to address non-deteminism when `K % BLOCK_K != 0`.

This change automatically sets the values of the loaded A and B to 0 when the bounds are outside the K dimension.

I believe this is the issue faced in https://github.com/stanford-futuredata/stk/issues/11, as the `K dim = 8` in that repro, which is not a multiple of `BLOCK_K=32`.