### PR TITLE
Cleanup `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup, find_packages
-import torch
 
 extra_deps = {}
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,9 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
+install_requires = [
+    'torch>=2.3.0,<2.4',
+    'triton>=2.1.0',
+]
 
 extra_deps = {}
 
@@ -23,8 +28,6 @@ setup(
         "Operating System :: Unix",
     ],
     packages=find_packages(),
-    install_requires=[
-        "triton>=2.1.0",
-    ],
+    install_requires=install_requires,
     extras_require=extra_deps,
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extra_deps['dev'] = [
     'absl-py',
 ]
 
-extra_deps['all'] = set(dep for deps in extra_deps.values() for dep in deps)
+extra_deps['all'] = list(set(dep for deps in extra_deps.values() for dep in deps))
 
 setup(
     name="stanford-stk",


### PR DESCRIPTION
This PR improves `setup.py` in several ways:

1. It fixes a small type error with `extra_deps['all']`.
2. It adds torch as a requirement in `install_requires`. This was missing before even though the library requires `torch`.
3. We deleted the import of `torch` in `setup.py`. Since `setup.py` does not actually use any `torch` functions, this import is unnecessary.